### PR TITLE
[Pull Request] TConstElementBoxIterator is deprecated in 4.26

### DIFF
--- a/Source/ExportNavRuntime/Private/ExternRecastNavMeshGenetator.cpp
+++ b/Source/ExportNavRuntime/Private/ExternRecastNavMeshGenetator.cpp
@@ -43,12 +43,9 @@ void FExternExportNavMeshGenerator::ExternExportNavigationData(const FString& Fi
 				uint8 AreaId;
 			};
 			TArray<FAreaExportData> AreaExport;
-
-			for (FNavigationOctree::TConstElementBoxIterator<FNavigationOctree::DefaultStackAllocator> It(*NavOctree, TotalNavBounds);
-				It.HasPendingElements();
-				It.Advance())
+			NavOctree->FindElementsWithBoundsTest(TotalNavBounds, [&](const FNavigationOctreeElement& Element)
+			
 			{
-				const FNavigationOctreeElement& Element = It.GetCurrentElement();
 				const bool bExportGeometry = Element.Data->HasGeometry() && Element.ShouldUseGeometry(DestNavMesh->GetConfig());
 
 				if (bExportGeometry && Element.Data->CollisionData.Num())
@@ -116,7 +113,7 @@ void FExternExportNavMeshGenerator::ExternExportNavigationData(const FString& Fi
 						}
 					}
 				}
-			}
+			});
 
 			UWorld* NavigationWorld = GetWorld();
 			for (int32 LevelIndex = 0; LevelIndex < NavigationWorld->GetNumLevels(); ++LevelIndex)


### PR DESCRIPTION
TOctree has been deprecated and FNavigationOctree has been made to extend TOctree2. TOctree2 provides a similar functionality method:

`inline void FindElementsWithBoundsTest(const FBoxCenterAndExtent& BoxBounds, const IterateBoundsFunc& Func) const`